### PR TITLE
escape '<' & '>' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ Gitを使用しない場合、最新のタグからzipをダウンロードし�
     $java -cp .\target\*;.\target\dependency\* nablarch.fw.batch.ee.Main <batch-job名>
 ```
 
-<batch-job名>の指定例を示します。
+\<batch-job名>の指定例を示します。
 
 ```
     $java -cp .\target\*;.\target\dependency\* nablarch.fw.batch.ee.Main zip-code-truncate-table
 ```
 
-<batch-job名>を変えることで、CSVからDBおよびDBからCSVへのデータ保存と、DBのTRUNCATE処理を行うことができます。
+\<batch-job名\>を変えることで、CSVからDBおよびDBからCSVへのデータ保存と、DBのTRUNCATE処理を行うことができます。
 実行後、次のCSVファイルやテーブルを見て処理結果を確認してください。
 
 動作させることができる処理は、次の通りです。
@@ -98,24 +98,24 @@ Gitを使用しない場合、最新のタグからzipをダウンロードし�
         * ZIP_CODE_DATAテーブル と ZIP_CODE_DATA_WORKテーブル のデータを削除する、Batchletステップのバッチです。
 * ETLとJBatchを利用
     * 郵便番号登録ETLバッチ(SQL*LoaderによるCSV→DB)
-        * <チェックアウトディレクトリ>/testdata/input/KEN_ALL.CSV を入力元とし、SQL*Loaderにより ZIP_CODE_DATA テーブルにデータを登録します。
+        * \<チェックアウトディレクトリ\>/testdata/input/KEN_ALL.CSV を入力元とし、SQL*Loaderにより ZIP_CODE_DATA テーブルにデータを登録します。
         * __SQL*Loaderを使用するため、実行する際はデータベースをOracleに変更してください。__ 変更方法は[DBの変更について](#6. DBの変更について)を見てください。
         * SQL\*Loaderでエラーが出た場合、testdata/sqlloader/output/にSQL\*Loaderのログが出力されるため、確認してください。
     * 郵便番号登録ETLバッチ(SQL*Loaderを使わないCSV→DB)
-        * <チェックアウトディレクトリ>/testdata/input/KEN_ALL.CSV を入力元とし、ZIP_CODE_DATA テーブルにデータを登録します。
+        * \<チェックアウトディレクトリ\>/testdata/input/KEN_ALL.CSV を入力元とし、ZIP_CODE_DATA テーブルにデータを登録します。
         * SQL*Loaderは使いません。
     * 郵便番号出力バッチ(DB→CSV)
-        * ZIP_CODE_DATAテーブルのデータを <チェックアウトディレクトリ>/testdata/output 以下に出力します。
+        * ZIP_CODE_DATAテーブルのデータを \<チェックアウトディレクトリ\>/testdata/output 以下に出力します。
 
-動作させる処理は、引数の<batch-job名>を変更することで選択できます。
+動作させる処理は、引数の\<batch-job名\>を変更することで選択できます。
 
 * JBatchのみ利用（ETLなし）
-    * <batch-job名>に「bonus-calculate」を指定すると、賞与計算バッチが実行されます。
-    * <batch-job名>に「zip-code-truncate-table」を指定すると、郵便番号テーブルTRUNCATEバッチが実行されます。
+    * \<batch-job名\>に「bonus-calculate」を指定すると、賞与計算バッチが実行されます。
+    * \<batch-job名\>に「zip-code-truncate-table」を指定すると、郵便番号テーブルTRUNCATEバッチが実行されます。
 * ETLとJBatchを利用
-    * <batch-job名>に「etl-zip-code-csv-to-db-insert-batchlet」を指定すると、郵便番号登録ETLバッチ(SQL*LoaderによるCSV→DB)が実行されます。
-    * <batch-job名>に「etl-zip-code-csv-to-db-chunk」を指定すると、郵便番号登録ETLバッチ(SQL*Loaderを使わないCSV→DB)が実行されます。
-    * <batch-job名>に「etl-zip-code-db-to-csv-chunk」を指定すると、郵便番号出力バッチが実行されます。
+    * \<batch-job名\>に「etl-zip-code-csv-to-db-insert-batchlet」を指定すると、郵便番号登録ETLバッチ(SQL*LoaderによるCSV→DB)が実行されます。
+    * \<batch-job名\>に「etl-zip-code-csv-to-db-chunk」を指定すると、郵便番号登録ETLバッチ(SQL*Loaderを使わないCSV→DB)が実行されます。
+    * \<batch-job名\>に「etl-zip-code-db-to-csv-chunk」を指定すると、郵便番号出力バッチが実行されます。
 
 
 なお、インプットのCSVデータは、下記サイトより取得できる郵便番号データ（全国一括）を元にしています。

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Gitを使用しない場合、最新のタグからzipをダウンロードし�
     $java -cp .\target\*;.\target\dependency\* nablarch.fw.batch.ee.Main <batch-job名>
 ```
 
-\<batch-job名>の指定例を示します。
+\<batch-job名\>の指定例を示します。
 
 ```
     $java -cp .\target\*;.\target\dependency\* nablarch.fw.batch.ee.Main zip-code-truncate-table


### PR DESCRIPTION
Markdown要素をエスケープして、HTML上正しく表示されるようにしました。