### PR TITLE
messages.propertiesの誤りおよび不足を訂正

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,7 +1,6 @@
 nablarch.core.validation.ee.SystemChar.message={charsetDef}で入力してください。
 nablarch.core.validation.ee.Length.min.message={min}文字以上で入力してください。
 nablarch.core.validation.ee.Length.max.message={max}文字以内で入力してください。
-nablarch.core.validation.ee.Length.fixed.message={min}文字で入力してください。
 nablarch.core.validation.ee.Length.min.max.message={max}文字以内{min}文字以上で入力してください。
 nablarch.core.validation.ee.Required.message=必須項目です。
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,6 +1,7 @@
 nablarch.core.validation.ee.SystemChar.message={charsetDef}で入力してください。
 nablarch.core.validation.ee.Length.min.message={min}文字以上で入力してください。
-nablarch.core.validation.ee.Length.max.message={max)文字以内で入力してください。
+nablarch.core.validation.ee.Length.max.message={max}文字以内で入力してください。
+nablarch.core.validation.ee.Length.fixed.message={min}文字で入力してください。
 nablarch.core.validation.ee.Length.min.max.message={max}文字以内{min}文字以上で入力してください。
 nablarch.core.validation.ee.Required.message=必須項目です。
 


### PR DESCRIPTION
BeanValidationで利用されるメッセージが足りていないため、追加する