### PR TITLE
exampleのpom.xmlでバージョンが明記されているものについてバージョンを現行バージョンに追随させる

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
       <plugin>
         <groupId>com.nablarch.etl</groupId>
         <artifactId>nablarch-etl-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>5-NEXT-SNAPSHOT</version>
         <configuration>
           <classes>
             <param>com.nablarch.example.app.batch.ee.dto.csv.ZipCodeDto</param>


### PR DESCRIPTION
## 背景
https://nablarch.atlassian.net/jira/software/c/projects/NAB/issues/NAB-401

## やったこと
nablarch-etl-maven-pluginのバージョンを最新のSNAPSHOTに更新。

## 確認したこと
`mvn nablarch-etl:generate-ctrl-file` コマンドの出力の現新比較。