### PR TITLE
JBeretのバージョンを上げたことによる、JBeretに最低限必要な依存関係についてのバージョン見直し

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,19 +272,25 @@
     <dependency>
       <groupId>org.jboss.marshalling</groupId>
       <artifactId>jboss-marshalling</artifactId>
-      <version>2.0.12.Final</version>
+      <version>2.1.3.Final</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+      <version>3.5.3.Final</version>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-core-impl</artifactId>
-      <version>5.0.0.SP1</version>
+      <version>5.0.1.Final</version>
     </dependency>
 
     <dependency>
       <groupId>org.wildfly.security</groupId>
       <artifactId>wildfly-elytron-security-manager</artifactId>
-      <version>1.19.0.Final</version>
+      <version>2.2.2.Final</version>
     </dependency>
 
     <dependency>
@@ -302,7 +308,7 @@
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
-      <version>5.0.0.SP1</version>
+      <version>5.0.1.Final</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
https://github.com/nablarch/nablarch-example-batch-ee/pull/89 でJBeretのバージョンを`2.1.4.Final`に上げたため、[ドキュメント](https://github.com/jberet/jsr352/tree/2.1.4.Final#batch-application-dependencies)で案内されている最低限必要な依存関係についてバージョンを見直した。

各バージョンは、[jboss-parent](https://github.com/jberet/jsr352/blob/2.1.4.Final/pom.xml)で案内されているバージョンに合わせた。

`jboss-logging`については、`org.hibernate.validator:hibernate-validator:8.0.0.Final`や`org.jboss.weld:weld-core-impl:5.0.1.Final`、`org.wildfly.security:wildfly-elytron-security-manager:2.2.2.Final`で推移的に呼ばれてはいるが、ドキュメントで必要な依存関係として案内されているため、利用者が混乱しないように追加した。（Nablarchのマイグレーションガイドでも使いするように案内している。）