### PR TITLE
不要なplugin、reporting、extensionsの削除

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,16 +135,6 @@
           <useManifestOnlyJar>false</useManifestOnlyJar>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.3</version>
-        <configuration>
-          <excludes>
-            <exclude>**/com/nablarch/example/app/entity/*</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -167,14 +157,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-
-    <extensions>
-      <extension>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-webdav-jackrabbit</artifactId>
-        <version>3.0.0</version>
-      </extension>
-    </extensions>
 
   </build>
 
@@ -393,25 +375,5 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-report-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </reporting>
 
 </project>


### PR DESCRIPTION
## 修正内容
Nablarch 6移行に伴い、以下の不要な定義を削除しました。

- jacoco-maven-plugin
このプラグインの設定はアーキタイプと異なるため、メンテナンスを考慮し削除する。
そもそもExampleではカバレッジを基に何かアクションをするなどがないため、メンテナンスする意義がない。

- wagon-webdav-jackrabbit
[ドキュメント](https://maven.apache.org/wagon/wagon-providers/wagon-webdav-jackrabbit/)より、非推奨である。
Apache Maven WagonでWebDAVサーバへデプロイするための拡張であるが、Exampleでの使用用途が不明であるため削除する。

- reporting定義
reporting定義内のjacocoプラグインのバージョンが古いことに加え、そもそもExampleではレポートを生成しないため削除する。

## 動作確認
動作確認はMavenのバージョン`3.9.9`を使用して行った。
- [x] `mvn test`が成功すること
- [x] Readme通り動作すること
※直接機能に影響がありそうなバージョンアップはないため、代表値のみ確認
- [x] 今回の修正でログに警告が増えていないこと 